### PR TITLE
Validate neighbor seat calculations

### DIFF
--- a/__tests__/neighbors.test.ts
+++ b/__tests__/neighbors.test.ts
@@ -1,0 +1,20 @@
+import { neighbors } from '../lib/neighbors';
+
+describe('neighbors', () => {
+  it('returns correct neighbors for first seat', () => {
+    expect(neighbors(0, 3)).toEqual({ left: 2, right: 1 });
+  });
+
+  it('returns correct neighbors for last seat', () => {
+    expect(neighbors(2, 3)).toEqual({ left: 1, right: 0 });
+  });
+
+  it('throws on seat out of range', () => {
+    expect(() => neighbors(3, 3)).toThrow('seat must be within range');
+  });
+
+  it('throws on non-positive player count', () => {
+    expect(() => neighbors(0, 0)).toThrow('number of players must be positive');
+  });
+});
+

--- a/lib/neighbors.ts
+++ b/lib/neighbors.ts
@@ -1,4 +1,15 @@
-export const neighbors = (seat: number, n: number) => ({
-  left: (seat - 1 + n) % n,
-  right: (seat + 1) % n,
-})
+export const neighbors = (seat: number, n: number) => {
+  if (!Number.isInteger(seat) || !Number.isInteger(n)) {
+    throw new Error('seat and n must be integers');
+  }
+  if (n <= 0) {
+    throw new Error('number of players must be positive');
+  }
+  if (seat < 0 || seat >= n) {
+    throw new Error('seat must be within range 0..n-1');
+  }
+  return {
+    left: (seat - 1 + n) % n,
+    right: (seat + 1) % n,
+  };
+};


### PR DESCRIPTION
## Summary
- guard against invalid seats and player counts in neighbor lookup
- add tests for neighbor computations and error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac986fc03483279a1c9af122c0126e