### PR TITLE
fix expansion summary pluralization

### DIFF
--- a/__tests__/expansions-summary.test.ts
+++ b/__tests__/expansions-summary.test.ts
@@ -1,0 +1,15 @@
+import { getWonderBoardSummary } from '../app/setup/getWonderBoardSummary';
+
+describe('getWonderBoardSummary', () => {
+  it('returns base message when no expansions selected', () => {
+    expect(getWonderBoardSummary(0)).toBe('7 original wonder boards available');
+  });
+
+  it('returns singular expansion for one selected', () => {
+    expect(getWonderBoardSummary(1)).toBe('9 wonder boards available (7 base + 2 expansion)');
+  });
+
+  it('returns plural expansions for multiple selected', () => {
+    expect(getWonderBoardSummary(2)).toBe('11 wonder boards available (7 base + 4 expansions)');
+  });
+});

--- a/app/setup/expansions.tsx
+++ b/app/setup/expansions.tsx
@@ -5,6 +5,7 @@ import { Platform, Pressable, ScrollView, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, H1, H2, P, ToggleRow } from '../../components/ui';
 import { useSetupStore } from '../../store/setupStore';
+import { getWonderBoardSummary } from './getWonderBoardSummary';
 
 export default function ExpansionsScreen() {
   const { expansions, toggleExpansion } = useSetupStore();
@@ -90,10 +91,7 @@ export default function ExpansionsScreen() {
                `Base Game + ${getSelectedCount()} Expansion${getSelectedCount() > 1 ? 's' : ''}`}
             </P>
             <P className="text-parchment/60 text-sm">
-              {getSelectedCount() === 0 ? 
-                '7 original wonder boards available' :
-                `${7 + getSelectedCount() * 2} wonder boards available (7 base + ${getSelectedCount() * 2} expansion)`
-              }
+              {getWonderBoardSummary(getSelectedCount())}
             </P>
             
             {getSelectedCount() > 0 && (

--- a/app/setup/getWonderBoardSummary.ts
+++ b/app/setup/getWonderBoardSummary.ts
@@ -1,0 +1,6 @@
+export function getWonderBoardSummary(count: number): string {
+  if (count === 0) {
+    return '7 original wonder boards available';
+  }
+  return `${7 + count * 2} wonder boards available (7 base + ${count * 2} expansion${count > 1 ? 's' : ''})`;
+}


### PR DESCRIPTION
## Summary
- correctly pluralize expansion counts in setup summary
- add reusable wonder board summary helper
- test summary output for 0, 1, and multiple expansions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9ad8846c8327acc6092ab6091a7d