### PR TITLE
Implement unbiased shuffle utility

### DIFF
--- a/store/setupStore.ts
+++ b/store/setupStore.ts
@@ -2,6 +2,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import { shuffleArray } from '../utils/shuffle';
 
 export type GameHistoryEntry = {
   id: string;
@@ -241,10 +242,8 @@ export const useSetupStore = create<SetupState & SetupActions>()(
 
       randomizeSeating: () => {
         const state = get();
-        const shuffled = [...state.players]
-          .sort(() => Math.random() - 0.5)
-          .map(p => p.id);
-        
+        const shuffled = shuffleArray(state.players).map(p => p.id);
+
         set({ seating: shuffled });
       },
 
@@ -263,7 +262,7 @@ export const useSetupStore = create<SetupState & SetupActions>()(
       randomizeWonders: () => {
         const state = get();
         const availableWonders = get().getAvailableWonders();
-        const shuffledWonders = [...availableWonders].sort(() => Math.random() - 0.5);
+        const shuffledWonders = shuffleArray(availableWonders);
         
         const newWonders: Record<string, WonderAssignment> = {};
         state.players.forEach((player, index) => {

--- a/utils/shuffle.ts
+++ b/utils/shuffle.ts
@@ -1,0 +1,8 @@
+export function shuffleArray<T>(array: T[]): T[] {
+  const arr = array.slice();
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}


### PR DESCRIPTION
## Summary
- add Fisher-Yates shuffle helper
- use helper to randomize seating and wonders without bias

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: Unsupported engine; requires node >=20 <21)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c37eeb88327916b0d425191f5ee