### PR TITLE
Pluralize color mode references

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -66,10 +66,10 @@ export default function TabTwoScreen() {
           <ThemedText type="link">Learn more</ThemedText>
         </ExternalLink>
       </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
+        <Collapsible title="Components for light and dark modes">
+          <ThemedText>
+            This template has support for light and dark modes. The{' '}
+            <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
           what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
         </ThemedText>
         <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -1,5 +1,5 @@
 /**
- * Below are the colors that are used in the app. The colors are defined in the light and dark mode.
+ * Below are the colors that are used in the app. The colors are defined in the light and dark modes.
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 


### PR DESCRIPTION
## Summary
- clarify color comments for light and dark modes
- update Explore screen wording to pluralize color modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9d33d3c08327bd2469edfd6ed454