### PR TITLE
fix: resolve lint warnings and add display names

### DIFF
--- a/app/setup/edifice.tsx
+++ b/app/setup/edifice.tsx
@@ -74,17 +74,8 @@ export default function EdificeSelectionScreen() {
     router.push('/setup/game-summary');
   };
 
-  // Update the back navigation to be more robust
-  const handleBack = () => {
-    if (expansions.armada) {
-      // Go back to wonder selection to show shipyards
-      router.push('/setup/wonders');
-    } else {
-      router.back();
-    }
-  };  
-
-  const isComplete = selectedProjects.age1 && selectedProjects.age2 && selectedProjects.age3;
+  const isComplete =
+    selectedProjects.age1 && selectedProjects.age2 && selectedProjects.age3;
 
   return (
     <Screen>

--- a/app/setup/players.tsx
+++ b/app/setup/players.tsx
@@ -45,15 +45,11 @@ export default function PlayersScreen() {
     router.push('/setup/seating');
   };
 
-  const handleBack = () => {
-     router.back();
-  }; 
-
   const getExpansionText = () => {
     const active = Object.entries(expansions)
       .filter(([_, enabled]) => enabled)
       .map(([name]) => name.charAt(0).toUpperCase() + name.slice(1));
-    
+
     return active.length > 0 ? `Base + ${active.join(' + ')}` : 'Base Game Only';
   };
 

--- a/app/setup/scoring-mode.tsx
+++ b/app/setup/scoring-mode.tsx
@@ -13,10 +13,6 @@ export default function ScoringMode() {
     router.push('/setup/game-summary');
   };
 
-  const handleBack = () => {
-    router.back();
-  };  
-
   return (
     <Screen>
       <StepHeader current={5} />

--- a/app/setup/seating.tsx
+++ b/app/setup/seating.tsx
@@ -63,18 +63,14 @@ export default function SeatingScreen() {
     );
   };
 
-  const handleContinue = () => {
-    setSeating(selectedSeating);
-    router.push('/setup/wonders');
-  };
+    const handleContinue = () => {
+      setSeating(selectedSeating);
+      router.push('/setup/wonders');
+    };
 
-  const handleBack = () => {
-    router.back();
-  };  
-
-  const getPlayerName = (playerId: string) => {
-    return players.find(p => p.id === playerId)?.name || 'Unknown';
-  };
+    const getPlayerName = (playerId: string) => {
+      return players.find(p => p.id === playerId)?.name || 'Unknown';
+    };
 
   const getNeighbors = (playerId: string) => {
     const index = selectedSeating.indexOf(playerId);

--- a/app/setup/wonders.tsx
+++ b/app/setup/wonders.tsx
@@ -17,7 +17,7 @@ export default function WonderAssignmentScreen() {
   const [selectedSide, setSelectedSide] = useState<'day' | 'night'>('day');
   const [assigningToPlayer, setAssigningToPlayer] = useState<string | null>(null);
   const [showShipyards, setShowShipyards] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading] = useState(false);
 
   const getOrderedPlayers = useCallback(() => {
     if (seating.length === 0) return players;

--- a/components/scoring/ComprehensiveEndGameScoring.tsx
+++ b/components/scoring/ComprehensiveEndGameScoring.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     Alert,
-    Dimensions,
     Platform,
     ScrollView,
     StyleSheet,
@@ -197,8 +196,6 @@ const createDefaultScore = (maxStages: number = 0): PlayerScoreData => ({
   armadaDirectPoints: 0,
 });
 
-const { width } = Dimensions.get('window');
-const isSmallScreen = width < 375;
 
 // Optimized styles
 const styles = StyleSheet.create({
@@ -528,11 +525,17 @@ const styles = StyleSheet.create({
 });
 
 // Optimized Components
-const MotivationalMessage = React.memo(({ message }: { message: string }) => (
-  <View style={styles.motivationalMessage}>
-    <Text style={styles.motivationalText}>✨ {message}</Text>
-  </View>
-));
+const MotivationalMessage = React.memo(function MotivationalMessage({
+  message,
+}: {
+  message: string;
+}) {
+  return (
+    <View style={styles.motivationalMessage}>
+      <Text style={styles.motivationalText}>✨ {message}</Text>
+    </View>
+  );
+});
 
 interface NumericInputProps {
   label: string;
@@ -546,7 +549,7 @@ interface NumericInputProps {
   icon?: string;
 }
 
-const NumericInput = React.memo(({
+const NumericInput = React.memo(function NumericInput({
   label,
   value,
   onChangeValue,
@@ -555,8 +558,8 @@ const NumericInput = React.memo(({
   step = 1,
   suffix = '',
   helperText = '',
-  icon = ''
-}: NumericInputProps) => {
+  icon = '',
+}: NumericInputProps) {
   const canDecrement = value > min;
   const canIncrement = value < max;
 
@@ -635,13 +638,13 @@ interface ToggleButtonProps {
   icon?: string;
 }
 
-const ToggleButton = React.memo(({ 
+const ToggleButton = React.memo(function ToggleButton({
   label,
   value,
   onToggle,
   description = '',
-  icon = ''
-}: ToggleButtonProps) => {
+  icon = '',
+}: ToggleButtonProps) {
   const handlePress = useCallback(() => {
     requestAnimationFrame(() => onToggle(!value));
   }, [value, onToggle]);
@@ -690,15 +693,15 @@ interface CategorySectionProps {
   hidden?: boolean;
 }
 
-const CategorySection = React.memo(({ 
-  title, 
-  icon, 
-  description, 
-  children, 
+const CategorySection = React.memo(function CategorySection({
+  title,
+  icon,
+  description,
+  children,
   calculatedPoints,
   isCalculating = false,
-  hidden = false
-}: CategorySectionProps) => {
+  hidden = false,
+}: CategorySectionProps) {
   if (hidden) return null;
   
   return (


### PR DESCRIPTION
## Summary
- name memoized components for clearer display names
- remove unused variables across setup screens

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac9fb744b08327967b59ea3b1b2eec