### PR TITLE
fix scoring PlayerScore types

### DIFF
--- a/components/ui/scoring.tsx
+++ b/components/ui/scoring.tsx
@@ -5,7 +5,7 @@ import { Card } from './index';
 
 // Import the scoring engine for the results component
 import { Enhanced7WondersScoringEngine } from '../../lib/scoring/enhancedScoringEngine';
-import type { PlayerScore } from '../../types/game';
+import type { PlayerScore } from '../../lib/scoring/enhancedScoringEngine';
 
 // Numeric Input Component
 interface NumericInputProps {
@@ -412,7 +412,7 @@ function ScoreBreakdownRow({ icon, label, value }: { icon: string; label: string
 
 // Results Screen Component
 interface ScoringResultsProps {
-  playerScores: any[];
+  playerScores: PlayerScore[];
   gameSetup: any;
   onStartNewGame: () => void;
   onRecalculate: () => void;

--- a/lib/scoring/enhancedScoringEngine.ts
+++ b/lib/scoring/enhancedScoringEngine.ts
@@ -28,23 +28,23 @@ export class Enhanced7WondersScoringEngine {
    * Calculates the total score for a player by summing all supported categories.
    */
   static calculateTotalScore(player: PlayerScore): number {
-    const categories: Array<number | undefined> = [
-      player.military?.total,
-      player.treasury,
-      player.wonder?.total,
-      player.civilian,
-      player.commercial,
-      player.science?.total,
-      player.guilds?.total,
-      player.leaders,
-      player.cities?.total,
-      player.armada?.total,
-      player.edifice?.total,
-      player.navy?.total,
-      player.islands?.total,
+    const categories: number[] = [
+      player.military?.total ?? 0,
+      player.treasury ?? 0,
+      player.wonder?.total ?? 0,
+      player.civilian ?? 0,
+      player.commercial ?? 0,
+      player.science?.total ?? 0,
+      player.guilds?.total ?? 0,
+      player.leaders ?? 0,
+      player.cities?.total ?? 0,
+      player.armada?.total ?? 0,
+      player.edifice?.total ?? 0,
+      player.navy?.total ?? 0,
+      player.islands?.total ?? 0,
     ];
 
-    return categories.reduce((sum, value) => sum + (value ?? 0), 0);
+    return categories.reduce((sum, value) => sum + value, 0);
   }
 
   /**


### PR DESCRIPTION
## Summary
- align scoring results component with enhanced PlayerScore type
- ensure scoring engine sums category totals safely

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acabb7d50883279672f11b7576b6c5