### PR TITLE
Improve scoring responsiveness with cached calculations

### DIFF
--- a/components/scoring/CategoryDetailModal.tsx
+++ b/components/scoring/CategoryDetailModal.tsx
@@ -572,11 +572,11 @@ export default function CategoryDetailModal({ playerId, categoryId, onClose }: P
   const calculatedPoints = useMemo(() => {
     // Ensure an object even if score is undefined and coerce to any to satisfy calculateCategoryPoints
     const mergedScore: any = { ...(score || {}), ...localChanges };
-    return calculateCategoryPoints(categoryId, mergedScore, {
+    return calculateCategoryPoints(playerId, categoryId, mergedScore, {
       wonder: wonderData,
       expansions,
-    });
-  }, [score, localChanges, categoryId, wonderData, expansions]);
+    }, false);
+  }, [playerId, score, localChanges, categoryId, wonderData, expansions]);
 
   return (
     <SafeAreaView style={styles.container}>

--- a/components/scoring/QuickScoreScreen.tsx
+++ b/components/scoring/QuickScoreScreen.tsx
@@ -252,19 +252,18 @@ export default function QuickScoreScreen() {
   const visibleCategories = categories.filter(c => c.visible);
 
   const getCategoryPoints = useCallback((categoryId: string) => {
-    if (!currentScore) return 0;
-    
-    // Check if details are entered
-    const hasDetails = currentScore[`${categoryId}ShowDetails` as keyof typeof currentScore];
-    if (hasDetails) {
-      return calculateCategoryPoints(categoryId, currentScore, {
-        wonder: currentPlayer?.id ? wonders[currentPlayer.id] : undefined,
+    if (!currentPlayer || !currentScore) return 0;
+
+    return calculateCategoryPoints(
+      currentPlayer.id,
+      categoryId,
+      currentScore,
+      {
+        wonder: wonders[currentPlayer.id],
         expansions,
-      });
-    }
-    
-    return (currentScore as any)[`${categoryId}DirectPoints`] || 0;
-  }, [currentScore, currentPlayer, wonders, expansions]);
+      }
+    );
+  }, [currentPlayer, currentScore, wonders, expansions]);
 
   const getTotalPoints = useCallback(() => {
     if (!currentScore) return 0;


### PR DESCRIPTION
## Summary
- Cache category point calculations per player to avoid recalculating heavy logic on each tap
- Use cached calculations in quick score screen and skip caching for unsaved modal edits

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: Unsupported engine - requires node >=20 <21)*

------
https://chatgpt.com/codex/tasks/task_e_68ade884aaac83278c51071575e5fe86