### PR TITLE
Improve scoring performance and responsiveness

### DIFF
--- a/components/scoring/ComprehensiveEndGameScoring.tsx
+++ b/components/scoring/ComprehensiveEndGameScoring.tsx
@@ -806,19 +806,19 @@ export default function ComprehensiveEndGameScoring() {
     if (!currentPlayer) return;
     const playerId = currentPlayer.id;
 
-    startTransition(() => {
-      setPlayerScores(prev => ({
-        ...prev,
-        [playerId]: {
-          ...prev[playerId],
-          [field]: value
-        }
-      }));
+    InteractionManager.runAfterInteractions(() => {
+      startTransition(() => {
+        setPlayerScores(prev => ({
+          ...prev,
+          [playerId]: {
+            ...prev[playerId],
+            [field]: value
+          }
+        }));
+      });
     });
-
-    calculationCache.current.delete(`${playerId}-wonder`);
-    calculationCache.current.delete(`${playerId}-treasure`);
-    calculationCache.current.delete(`${playerId}-science`);
+    const category = field.replace(/[A-Z].*/, '');
+    calculationCache.current.delete(`${playerId}-${category}`);
     calculationCache.current.delete(`${playerId}-total`);
   }, [currentPlayer]);
 

--- a/components/scoring/QuickScoreScreen.tsx
+++ b/components/scoring/QuickScoreScreen.tsx
@@ -4,7 +4,7 @@ import {
     Alert,
     Modal,
     Platform,
-    ScrollView,
+    FlatList,
     StyleSheet,
     Text,
     TouchableOpacity,
@@ -86,11 +86,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     textAlign: 'center',
     fontStyle: 'italic',
-  },
-  categoryGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
   },
   categoryCard: {
     width: '48.5%',
@@ -342,63 +337,64 @@ export default function QuickScoreScreen() {
         </View>
       </View>
 
-      <ScrollView 
+      <FlatList
         style={{ flex: 1 }}
+        data={visibleCategories}
+        keyExtractor={(item) => item.id}
+        numColumns={2}
+        columnWrapperStyle={{ justifyContent: 'space-between' }}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
-      >
-        {/* Motivational Message */}
-        <View style={styles.motivationalCard}>
-          <Text style={styles.motivationalText}>
-            💫 Enter quick totals or tap &quot;Details&quot; for comprehensive tracking and personal analysis!
-          </Text>
-        </View>
+        ListHeaderComponent={
+          <View style={styles.motivationalCard}>
+            <Text style={styles.motivationalText}>
+              💫 Enter quick totals or tap "Details" for comprehensive tracking and personal analysis!
+            </Text>
+          </View>
+        }
+        ListFooterComponent={
+          <View style={styles.totalCard}>
+            <Text style={styles.totalLabel}>TOTAL SCORE</Text>
+            <Text style={styles.totalValue}>{getTotalPoints()}</Text>
+          </View>
+        }
+        renderItem={({ item: category }) => {
+          const points = getCategoryPoints(category.id);
+          const hasDetails = currentScore &&
+            (currentScore[`${category.id}ShowDetails` as keyof typeof currentScore] as boolean);
 
-        {/* Category Grid */}
-        <View style={styles.categoryGrid}>
-          {visibleCategories.map(category => {
-            const points = getCategoryPoints(category.id);
-            const hasDetails = currentScore[`${category.id}ShowDetails` as keyof typeof currentScore];
-            
-            return (
-              <View key={category.id} style={styles.categoryCard}>
-                <View style={styles.categoryHeader}>
-                  <Text style={styles.categoryIcon}>{category.icon}</Text>
-                  <Text style={styles.categoryTitle}>{category.title}</Text>
-                </View>
-                
-                <View style={styles.pointsDisplay}>
-                  <TouchableOpacity
-                    onPress={() => {
-                      const newValue = points > 0 ? 0 : 5;
-                      handleQuickEdit(category.id, newValue);
-                    }}
-                  >
-                    <Text style={[styles.pointsValue, hasDetails ? { color: '#10B981' } : null]}>
-                      {points}
-                    </Text>
-                  </TouchableOpacity>
-                  
-                  <TouchableOpacity
-                    style={styles.detailButton}
-                    onPress={() => handleCategoryPress(category.id)}
-                  >
-                    <Text style={styles.detailButtonText}>
-                      {hasDetails ? '✓ Details' : 'Details'}
-                    </Text>
-                  </TouchableOpacity>
-                </View>
+          return (
+            <View style={styles.categoryCard}>
+              <View style={styles.categoryHeader}>
+                <Text style={styles.categoryIcon}>{category.icon}</Text>
+                <Text style={styles.categoryTitle}>{category.title}</Text>
               </View>
-            );
-          })}
-        </View>
 
-        {/* Total Display */}
-        <View style={styles.totalCard}>
-          <Text style={styles.totalLabel}>TOTAL SCORE</Text>
-          <Text style={styles.totalValue}>{getTotalPoints()}</Text>
-        </View>
-      </ScrollView>
+              <View style={styles.pointsDisplay}>
+                <TouchableOpacity
+                  onPress={() => {
+                    const newValue = points > 0 ? 0 : 5;
+                    handleQuickEdit(category.id, newValue);
+                  }}
+                >
+                  <Text style={[styles.pointsValue, hasDetails ? { color: '#10B981' } : null]}>
+                    {points}
+                  </Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  style={styles.detailButton}
+                  onPress={() => handleCategoryPress(category.id)}
+                >
+                  <Text style={styles.detailButtonText}>
+                    {hasDetails ? '✓ Details' : 'Details'}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          );
+        }}
+      />
 
       {/* Footer */}
       <View style={styles.footer}>

--- a/components/scoring/scoringCalculations.ts
+++ b/components/scoring/scoringCalculations.ts
@@ -14,9 +14,10 @@ export function calculateCategoryPoints(
   context: CalculationContext,
   useCache: boolean = true
 ): number {
+  const cacheKey = `${playerId}-${categoryId}`;
   const cache = useScoringStore.getState().calculationCache;
-  if (useCache && cache.has(playerId)) {
-    return cache.get(playerId)!;
+  if (useCache && cache.has(cacheKey)) {
+    return cache.get(cacheKey)!;
   }
 
   // Return direct points if no details entered
@@ -73,7 +74,7 @@ export function calculateCategoryPoints(
   }
 
   if (useCache) {
-    cache.set(playerId, result);
+    cache.set(cacheKey, result);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- Cache score calculations per player & category
- Refactor scoring store to reduce copying and prune cache selectively
- Defer score updates until after interactions and virtualize quick score list

## Testing
- `npm test` *(fails: jest not found due to missing dependencies)*
- `npm run lint` *(fails: expo CLI not installed)*
- `npm run typecheck` *(fails: tsc not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68adf2698a1483278ca1a9dfe12a5945