### PR TITLE
refactor: optimize quick scoring screen

### DIFF
--- a/components/scoring/QuickCategoryItem.tsx
+++ b/components/scoring/QuickCategoryItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { shallow } from 'zustand/shallow';
 import { DetailedScoreData, useScoringStore } from '../../store/scoringStore';
@@ -30,9 +30,97 @@ export default React.memo(function QuickCategoryItem({
   onDetails,
   onQuickEdit,
 }: Props) {
-  // Use direct slice + shallow (stable snapshot; no object reconstruction)
+  // Map of category -> score fields to subscribe to
+  const CATEGORY_FIELDS: Record<string, (keyof DetailedScoreData)[]> = {
+    wonder: ['wonderDirectPoints', 'wonderShowDetails', 'wonderStagesBuilt', 'wonderEdificeStage'],
+    treasure: [
+      'treasureDirectPoints',
+      'treasureShowDetails',
+      'treasureTotalCoins',
+      'treasurePermanentDebt',
+      'treasureCardDebt',
+      'treasureTaxDebt',
+      'treasurePiracyDebt',
+      'treasureCommercialDebt',
+    ],
+    military: [
+      'militaryDirectPoints',
+      'militaryShowDetails',
+      'militaryTotalStrength',
+      'militaryStrengthPerAge',
+      'militaryPlayedDove',
+      'militaryDoveAges',
+      'militaryBoardingApplied',
+      'militaryBoardingReceived',
+      'militaryChainLinks',
+    ],
+    science: [
+      'scienceDirectPoints',
+      'scienceShowDetails',
+      'scienceCompass',
+      'scienceTablet',
+      'scienceGear',
+      'scienceNonCardCompass',
+      'scienceNonCardTablet',
+      'scienceNonCardGear',
+    ],
+    civilian: [
+      'civilianDirectPoints',
+      'civilianShowDetails',
+      'civilianShipPosition',
+      'civilianChainLinks',
+      'civilianTotalCards',
+    ],
+    commercial: [
+      'commercialDirectPoints',
+      'commercialShowDetails',
+      'commercialShipPosition',
+      'commercialChainLinks',
+      'commercialTotalCards',
+      'commercialPointCards',
+    ],
+    guilds: ['guildsDirectPoints', 'guildsShowDetails', 'guildsCardsPlayed'],
+    resources: [
+      'resourcesDirectPoints',
+      'resourcesShowDetails',
+      'resourcesBrownCards',
+      'resourcesGreyCards',
+      'discardRetrievals',
+    ],
+    cities: [
+      'citiesDirectPoints',
+      'citiesShowDetails',
+      'blackPointCards',
+      'blackTotalCards',
+      'blackNeighborPositive',
+      'blackNeighborNegative',
+      'blackPeaceDoves',
+    ],
+    leaders: ['leadersDirectPoints', 'leadersShowDetails', 'leadersPlayed', 'leadersAvailable'],
+    navy: ['navyDirectPoints', 'navyShowDetails', 'navyTotalStrength', 'navyPlayedBlueDove', 'navyDoveAges'],
+    islands: ['islandDirectPoints', 'islandShowDetails', 'islandCards'],
+    edifice: [
+      'edificeDirectPoints',
+      'edificeShowDetails',
+      'edificeRewards',
+      'edificePenalties',
+      'edificeProjectsContributed',
+    ],
+  };
+
+  // Subscribe only to needed fields for this category
   const playerScore = useScoringStore(
-    state => state.playerScores[playerId],
+    useCallback((state) => {
+      const allScores = state.playerScores[playerId];
+      if (!allScores) return undefined;
+      const slice: Partial<DetailedScoreData> = {};
+      const fields = CATEGORY_FIELDS[category.id] || [];
+      fields.forEach((k) => {
+        // @ts-ignore dynamic assignment
+        slice[k] = allScores[k];
+      });
+      return slice as DetailedScoreData;
+    }, [playerId, category.id]),
     shallow
   );
 


### PR DESCRIPTION
## Summary
- optimize quick scoring screen with FlatList, lazy detail modal, and deferred store init
- memoize category tiles and subscribe to narrow score slices

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --ignore-scripts --no-audit --no-fund` *(fails: Unsupported engine)*

------
https://chatgpt.com/codex/tasks/task_e_68af2b827e488327af6a285b08e5a56c