### PR TITLE
feat: unify setup screen layout

### DIFF
--- a/app/setup/expansions.tsx
+++ b/app/setup/expansions.tsx
@@ -1,9 +1,8 @@
 // app/setup/expansions.tsx - FIXED: Navigate to players first
 import { router } from 'expo-router';
 import React, { useState } from 'react';
-import { Platform, Pressable, ScrollView, Text, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Card, H1, H2, P, ToggleRow } from '../../components/ui';
+import { Pressable, Text, View } from 'react-native';
+import { Button, Card, H1, H2, P, ToggleRow, SetupScreen } from '../../components/ui';
 import { useSetupStore } from '../../store/setupStore';
 import { getWonderBoardSummary } from '../../utils/getWonderBoardSummary';
 
@@ -24,123 +23,96 @@ export default function ExpansionsScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#1C1A1A' }}>
-      <View style={{ 
-        flex: 1, 
-        backgroundColor: '#1C1A1A'
-      }}>
-        <ScrollView 
-          style={{ flex: 1 }}
-          contentContainerStyle={{
-            paddingHorizontal: 20,
-            paddingTop: Platform.OS === 'ios' ? 10 : 20,
-            paddingBottom: 120, // Space for fixed navigation
-          }}
-          showsVerticalScrollIndicator={false}
-        >
-          <H1>Choose Expansions</H1>
-          <P className="mb-6">Select which 7 Wonders expansions you want to include in this game.</P>
-          
-          <Card>
-            <H2>Base Game</H2>
-            <P className="mb-4">The core 7 Wonders experience is always included with 7 original wonder boards.</P>
-          </Card>
-
-          <Card>
-            <H2>Available Expansions</H2>
-            
-            <View style={{ gap: 4 }}>
-              <ExpansionToggleItem
-                name="Leaders"
-                enabled={expansions.leaders}
-                onToggle={() => toggleExpansion('leaders')}
-                description="Adds leader cards with special abilities drafted before each age"
-                wondersAdded="Rome, Abu Simbel"
-              />
-              
-              <ExpansionToggleItem
-                name="Cities"
-                enabled={expansions.cities}
-                onToggle={() => toggleExpansion('cities')}
-                description="Introduces diplomacy, debt, and teamwork mechanics"
-                wondersAdded="Byzantium, Petra"
-              />
-              
-              <ExpansionToggleItem
-                name="Armada"
-                enabled={expansions.armada}
-                onToggle={() => toggleExpansion('armada')}
-                description="Naval expansion with shipyards and fleet advancement"
-                wondersAdded="Siracusa + Shipyard Selection"
-              />
-              
-              <ExpansionToggleItem
-                name="Edifice"
-                enabled={expansions.edifice}
-                onToggle={() => toggleExpansion('edifice')}
-                description="Collaborative projects for shared benefits"
-                wondersAdded="Ur, Carthage"
-              />
-            </View>
-          </Card>
-
-          <Card>
-            <H2>Setup Summary</H2>
-            <P className="text-aurum mb-2">
-              {getSelectedCount() === 0 ? 'Base Game Only' : 
-               `Base Game + ${getSelectedCount()} Expansion${getSelectedCount() > 1 ? 's' : ''}`}
-            </P>
-            <P className="text-parchment/60 text-sm">
-              {getWonderBoardSummary(getSelectedCount())}
-            </P>
-            
-            {getSelectedCount() > 0 && (
-              <View style={{ marginTop: 8 }}>
-                <P className="text-parchment/70 text-sm">
-                  Active: {Object.entries(expansions)
-                    .filter(([_, enabled]) => enabled)
-                    .map(([name]) => name.charAt(0).toUpperCase() + name.slice(1))
-                    .join(', ')}
-                </P>
-              </View>
-            )}
-          </Card>
-        </ScrollView>
-
-        {/* Fixed Navigation at Bottom */}
-        <View style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          backgroundColor: '#1C1A1A',
-          paddingHorizontal: 20,
-          paddingVertical: 16,
-          paddingBottom: Platform.OS === 'ios' ? 34 : 16,
-          borderTopWidth: 1,
-          borderTopColor: 'rgba(243, 231, 211, 0.1)',
-          shadowColor: '#000',
-          shadowOffset: { width: 0, height: -2 },
-          shadowOpacity: 0.3,
-          shadowRadius: 4,
-          elevation: 8,
-        }}>
-          <View style={{ flexDirection: 'row', gap: 12 }}>
+    <SetupScreen
+      footer={
+        <View style={{ flexDirection: 'row' }}>
+          <View style={{ flex: 1, marginRight: 12 }}>
             <Button
               title="Back"
               variant="ghost"
               onPress={handleBack}
-              className="flex-1"
+              className="w-full"
             />
+          </View>
+          <View style={{ flex: 1 }}>
             <Button
               title="Continue to Players"
               onPress={handleContinue}
-              className="flex-1"
+              className="w-full"
             />
           </View>
         </View>
-      </View>
-    </SafeAreaView>
+      }
+    >
+      <H1>Choose Expansions</H1>
+      <P className="mb-6">Select which 7 Wonders expansions you want to include in this game.</P>
+
+      <Card>
+        <H2>Base Game</H2>
+        <P className="mb-4">The core 7 Wonders experience is always included with 7 original wonder boards.</P>
+      </Card>
+
+      <Card>
+        <H2>Available Expansions</H2>
+
+        <View style={{ gap: 4 }}>
+          <ExpansionToggleItem
+            name="Leaders"
+            enabled={expansions.leaders}
+            onToggle={() => toggleExpansion('leaders')}
+            description="Adds leader cards with special abilities drafted before each age"
+            wondersAdded="Rome, Abu Simbel"
+          />
+
+          <ExpansionToggleItem
+            name="Cities"
+            enabled={expansions.cities}
+            onToggle={() => toggleExpansion('cities')}
+            description="Introduces diplomacy, debt, and teamwork mechanics"
+            wondersAdded="Byzantium, Petra"
+          />
+
+          <ExpansionToggleItem
+            name="Armada"
+            enabled={expansions.armada}
+            onToggle={() => toggleExpansion('armada')}
+            description="Naval expansion with shipyards and fleet advancement"
+            wondersAdded="Siracusa + Shipyard Selection"
+          />
+
+          <ExpansionToggleItem
+            name="Edifice"
+            enabled={expansions.edifice}
+            onToggle={() => toggleExpansion('edifice')}
+            description="Collaborative projects for shared benefits"
+            wondersAdded="Ur, Carthage"
+          />
+        </View>
+      </Card>
+
+      <Card>
+        <H2>Setup Summary</H2>
+        <P className="text-aurum mb-2">
+          {getSelectedCount() === 0 ? 'Base Game Only' :
+           `Base Game + ${getSelectedCount()} Expansion${getSelectedCount() > 1 ? 's' : ''}`}
+        </P>
+        <P className="text-parchment/60 text-sm">
+          {getWonderBoardSummary(getSelectedCount())}
+        </P>
+
+        {getSelectedCount() > 0 && (
+          <View style={{ marginTop: 8 }}>
+            <P className="text-parchment/70 text-sm">
+              Active: {Object.entries(expansions)
+                .filter(([_, enabled]) => enabled)
+                .map(([name]) => name.charAt(0).toUpperCase() + name.slice(1))
+                .join(', ')}
+            </P>
+          </View>
+        )}
+      </Card>
+      <View style={{ height: 20 }} />
+    </SetupScreen>
   );
 }
 

--- a/app/setup/players.tsx
+++ b/app/setup/players.tsx
@@ -1,9 +1,8 @@
 // app/setup/players.tsx - Fixed version with proper scrolling and safe areas
 import { router } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, KeyboardAvoidingView, Platform, ScrollView, TextInput, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Card, H1, H2, P } from '../../components/ui'; // removed unused Screen
+import { Alert, TextInput, View, ScrollView } from 'react-native';
+import { Button, Card, H1, H2, P, SetupScreen } from '../../components/ui';
 import { AnimatedButton, PlayerListItem } from '../../components/ui/enhanced';
 import { useSetupStore } from '../../store/setupStore';
 
@@ -54,30 +53,32 @@ export default function PlayersScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#1C1A1A' }}>
-      <KeyboardAvoidingView 
-        style={{ flex: 1 }} 
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      >
-        <View style={{ 
-          flex: 1, 
-          backgroundColor: '#1C1A1A', 
-          paddingHorizontal: 20,
-          paddingTop: 10
-        }}>
-          <ScrollView 
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={{ 
-              paddingBottom: 120, // Extra space for navigation buttons
-              flexGrow: 1 
-            }}
-            style={{ flex: 1 }}
-          >
-            <H1>Players</H1>
-            {/* className -> style */}
-            <P style={{ marginBottom: 16 }}>Add 3-7 players for your game.</P>
-            
-            <Card>
+    <SetupScreen
+      footer={
+        <View style={{ flexDirection: 'row' }}>
+          <View style={{ flex: 1, marginRight: 12 }}>
+            <Button
+              title="Back"
+              variant="ghost"
+              onPress={() => router.back()}
+              className="w-full"
+            />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Button
+              title={`Continue (${players.length})`}
+              onPress={handleStartGame}
+              disabled={players.length < 3}
+              className="w-full"
+            />
+          </View>
+        </View>
+      }
+    >
+      <H1>Players</H1>
+      <P style={{ marginBottom: 16 }}>Add 3-7 players for your game.</P>
+
+      <Card>
               <H2>Game Setup</H2>
               {/* className -> style (text-aurum) */}
               <P style={{ color: '#C4A24C' }}>
@@ -122,7 +123,7 @@ export default function PlayersScreen() {
               <Card>
                 <H2>Current Players ({players.length})</H2>
                 <View style={{ maxHeight: 300 }}>
-                  <ScrollView 
+                  <ScrollView
                     showsVerticalScrollIndicator={false}
                     nestedScrollEnabled
                   >
@@ -130,9 +131,7 @@ export default function PlayersScreen() {
                       <PlayerListItem
                         key={player.id}
                         player={player}
-                        // pass the correctly typed handler (id => void)
                         onRemove={handleRemovePlayer}
-                        // className -> style
                         style={{ marginBottom: 8 }}
                       />
                     ))}
@@ -140,43 +139,7 @@ export default function PlayersScreen() {
                 </View>
               </Card>
             )}
-
-            {/* Add some space before navigation */}
-            <View style={{ height: 20 }} />
-          </ScrollView>
-
-          {/* Fixed Navigation at Bottom */}
-          <View style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            backgroundColor: '#1C1A1A',
-            paddingHorizontal: 20,
-            paddingVertical: 16,
-            paddingBottom: Platform.OS === 'ios' ? 34 : 16, // Account for home indicator
-            borderTopWidth: 1,
-            borderTopColor: 'rgba(243, 231, 211, 0.1)',
-          }}>
-            <View style={{ flexDirection: 'row', gap: 12 }}>
-              <Button
-                title="Back"
-                variant="ghost"
-                onPress={() => router.back()}
-                // className -> style
-                style={{ flex: 1 }}
-              />
-              <Button
-                title={`Continue (${players.length})`}
-                onPress={handleStartGame}
-                disabled={players.length < 3}
-                // className -> style
-                style={{ flex: 1 }}
-              />
-            </View>
-          </View>
-        </View>
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+      <View style={{ height: 20 }} />
+    </SetupScreen>
   );
 }

--- a/app/setup/seating.tsx
+++ b/app/setup/seating.tsx
@@ -1,9 +1,8 @@
 // app/setup/seating.tsx - Fixed modal and enhanced with age/conflict modes
 import { router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { Alert, Platform, ScrollView, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { Button, Card, H1, H2, P } from '../../components/ui';
+import { Alert, View } from 'react-native';
+import { Button, Card, H1, H2, P, SetupScreen } from '../../components/ui';
 import {
   AerialTableView,
   DragDropPlayerList,
@@ -100,26 +99,32 @@ export default function SeatingScreen() {
   : null;
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#1C1A1A' }}>
-      <View style={{ 
-        flex: 1, 
-        backgroundColor: '#1C1A1A', 
-        paddingHorizontal: 20,
-        paddingTop: Platform.OS === 'ios' ? 10 : 20
-      }}>
-        <ScrollView 
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ 
-            paddingBottom: 120,
-            flexGrow: 1 
-          }}
-          style={{ flex: 1 }}
-          scrollEnabled={!showPlayerDetails}
-        >
-          <H1>Table Seating</H1>
-          <P className="mb-4">
-            Arrange players around the table. Use the tabs below to visualize different game phases.
-          </P>
+    <SetupScreen
+      footer={
+        <View style={{ flexDirection: 'row' }}>
+          <View style={{ flex: 1, marginRight: 12 }}>
+            <Button
+              title="Back to Players"
+              variant="ghost"
+              onPress={() => router.back()}
+              className="w-full"
+            />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Button
+              title="Continue to Wonders"
+              onPress={handleContinue}
+              className="w-full"
+              disabled={selectedSeating.length < 3 || selectedSeating.length > 7}
+            />
+          </View>
+        </View>
+      }
+    >
+      <H1>Table Seating</H1>
+      <P className="mb-4">
+        Arrange players around the table. Use the tabs below to visualize different game phases.
+      </P>
 
           {/* Game Setup Info */}
           <Card>
@@ -159,68 +164,37 @@ export default function SeatingScreen() {
             />
           </Card>
 
-          {/* Seating Controls */}
-          <SeatingControls
-            onRandomize={handleRandomize}
-            onOptimalSeating={handleOptimalSeating}
-          />
-
-          {/* Drag & Drop Player Reordering */}
-          <Card>
-            <H2>Player Order</H2>
-            <P className="mb-3 text-parchment/70 text-sm">
-              Drag and drop to reorder players • Hold and drag any player to rearrange seating
-            </P>
-            <DragDropPlayerList
-              playerIds={selectedSeating}
-              getPlayerName={getPlayerName}
-              getNeighbors={getNeighbors}
-              onReorder={handlePlayerReorder}
-              disabled={showPlayerDetails}
-            />
-          </Card>
-
-          <View style={{ height: 20 }} />
-        </ScrollView>
-
-        {/* Fixed Navigation */}
-        <View style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          backgroundColor: '#1C1A1A',
-          paddingHorizontal: 20,
-          paddingVertical: 16,
-          paddingBottom: Platform.OS === 'ios' ? 34 : 16,
-          borderTopWidth: 1,
-          borderTopColor: 'rgba(243, 231, 211, 0.1)',
-        }}>
-          <View style={{ flexDirection: 'row', gap: 12 }}>
-            <Button
-              title="Back to Players"
-              variant="ghost"
-              onPress={() => router.back()}
-              className="flex-1"
-            />
-            <Button
-              title="Continue to Wonders"
-              onPress={handleContinue}
-              className="flex-1"
-              disabled={selectedSeating.length < 3 || selectedSeating.length > 7}
-            />
-          </View>
-        </View>
-      </View>
-
-      {/* Player Details Modal - Properly isolated */}
-      <PlayerDetailsModal
-        visible={showPlayerDetails}
-        player={selectedPlayerData}
-        position={selectedPlayer ? selectedSeating.indexOf(selectedPlayer) + 1 : 0}
-        neighbors={selectedPlayer ? getNeighbors(selectedPlayer) : { left: '', right: '' }}
-        onClose={handleCloseDetails}
+      {/* Seating Controls */}
+      <SeatingControls
+        onRandomize={handleRandomize}
+        onOptimalSeating={handleOptimalSeating}
       />
-    </SafeAreaView>
+
+      {/* Drag & Drop Player Reordering */}
+      <Card>
+        <H2>Player Order</H2>
+        <P className="mb-3 text-parchment/70 text-sm">
+          Drag and drop to reorder players • Hold and drag any player to rearrange seating
+        </P>
+        <DragDropPlayerList
+          playerIds={selectedSeating}
+          getPlayerName={getPlayerName}
+          getNeighbors={getNeighbors}
+          onReorder={handlePlayerReorder}
+          disabled={showPlayerDetails}
+        />
+      </Card>
+
+      <View style={{ height: 20 }} />
+    </SetupScreen>
+
+    {/* Player Details Modal - Properly isolated */}
+    <PlayerDetailsModal
+      visible={showPlayerDetails}
+      player={selectedPlayerData}
+      position={selectedPlayer ? selectedSeating.indexOf(selectedPlayer) + 1 : 0}
+      neighbors={selectedPlayer ? getNeighbors(selectedPlayer) : { left: '', right: '' }}
+      onClose={handleCloseDetails}
+    />
   );
 }

--- a/components/ui/index.tsx
+++ b/components/ui/index.tsx
@@ -215,3 +215,4 @@ export function ToggleRow(
 export * from './enhanced';
 export * from './wonder-assignment';
 export * from './wonder-card';
+export * from './setup-screen';

--- a/components/ui/setup-screen.tsx
+++ b/components/ui/setup-screen.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import { Screen } from './index';
+
+interface SetupScreenProps {
+  children: React.ReactNode;
+  footer: React.ReactNode;
+  keyboardOffset?: number;
+}
+
+export function SetupScreen({ children, footer, keyboardOffset = 0 }: SetupScreenProps) {
+  return (
+    <Screen>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={keyboardOffset}
+      >
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingBottom: 120 }}
+          showsVerticalScrollIndicator={false}
+        >
+          {children}
+        </ScrollView>
+        <View
+          style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            backgroundColor: '#1C1A1A',
+            paddingHorizontal: 20,
+            paddingVertical: 16,
+            paddingBottom: Platform.OS === 'ios' ? 34 : 16,
+            borderTopWidth: 1,
+            borderTopColor: 'rgba(243, 231, 211, 0.1)',
+          }}
+        >
+          {footer}
+        </View>
+      </KeyboardAvoidingView>
+    </Screen>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `SetupScreen` component for consistent safe area, scrolling and bottom nav spacing
- refactor player, expansion and seating setup flows to use new layout component
- export new screen utility from ui package

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af47eaa77483279569d7a042eec979