### PR TITLE
build(android): disable new architecture for first builds

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -19,6 +19,8 @@ module.exports = ({ config }) => {
   return {
     ...config,
 
+    newArchEnabled: false, // explicitly disable the new architecture
+
     // iOS / Android identifiers & build numbers
     ios: {
       ...(config.ios || {}),


### PR DESCRIPTION
## Summary
disable new architecture for first builds

## Testing
- [ ] iOS
- [ ] Android

